### PR TITLE
🐛 Fix building of schemas for classes that extend BaseRouter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@essential-projects/errors_ts": "^1.0.0",
     "@essential-projects/foundation": "^1.0.0-rc3",
     "@essential-projects/http_contracts": "^1.0.0-rc3",
+    "@types/express": "^4.0.37",
     "addict-ioc": "^2.2.8",
     "body-parser": "^1.15.2",
     "express": "^4.14.0",
@@ -26,7 +27,6 @@
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.0.0-rc3",
-    "@types/express": "^4.0.37",
     "@types/node": "^8.0.27",
     "eslint": "^4.6.1",
     "eslint-config-5minds": "0.1.0",


### PR DESCRIPTION
## What did you change?

I made the express-typings a regular dependency, so JSON-Schemas for classes that extend the BaseRouter can be built without error

## How can others test the changes?

With this fix, running `npm run build-schemas` in messagebus_http should work again. Before you'd get [these](http://ci.process-engine.io:8080/blue/organizations/jenkins/essential-projects_node-lts%2Fmessagebus_http/detail/develop/16/pipeline/#step-64-log-9) errors:

```
/var/lib/jenkins/workspace/lts_messagebus_http_develop-5LVEXU72VISX7SGXCD4IXABHCDCDIKHN5KQBEE64T7GOERYE6IBA/node_modules/@essential-projects/http_node/dist/base_router.d.ts (1,23): Cannot find type definition file for 'express'.

/var/lib/jenkins/workspace/lts_messagebus_http_develop-5LVEXU72VISX7SGXCD4IXABHCDCDIKHN5KQBEE64T7GOERYE6IBA/node_modules/@essential-projects/http_node/dist/error_handler.d.ts (1,23): Cannot find type definition file for 'express'.

/var/lib/jenkins/workspace/lts_messagebus_http_develop-5LVEXU72VISX7SGXCD4IXABHCDCDIKHN5KQBEE64T7GOERYE6IBA/node_modules/@essential-projects/http_node/dist/http_extension.d.ts (2,23): Cannot find type definition file for 'express'.
```

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
