### PR TITLE
Feature/remove old datastore implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@essential-projects/bootstrapper_contracts": "feature~remove_old_datastore_implementation",
+    "@essential-projects/bootstrapper_contracts": "^1.0.0",
     "@essential-projects/errors_ts": "^1.0.0",
     "@essential-projects/http_contracts": "^2.0.0",
     "@types/express": "^4.0.37",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://www.npmjs.com"
   },
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Tools for the HTTP protocol based on node",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",
@@ -14,9 +14,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@essential-projects/core_contracts": "^2.0.0",
+    "@essential-projects/bootstrapper_contracts": "feature~remove_old_datastore_implementation",
     "@essential-projects/errors_ts": "^1.0.0",
-    "@essential-projects/foundation": "^1.0.0",
     "@essential-projects/http_contracts": "^2.0.0",
     "@types/express": "^4.0.37",
     "addict-ioc": "^2.2.8",

--- a/src/base_router.ts
+++ b/src/base_router.ts
@@ -1,4 +1,3 @@
-import {runtime} from '@essential-projects/foundation';
 import {IHttpRouter} from '@essential-projects/http_contracts';
 import * as Express from 'express';
 
@@ -29,10 +28,34 @@ export class BaseRouter implements IHttpRouter {
   }
 
   public initialize(): Promise<any> | any {
-    return runtime.invokeAsPromiseIfPossible(this.initializeRouter, this);
+    return this.invokeAsPromiseIfPossible(this.initializeRouter, this);
   }
 
   public initializeRouter(): Promise<any> | any { return; }
 
   public dispose(): Promise<void> | void { return; }
+
+  // Taken from the foundation, to remove the need for that package.
+  private invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
+
+    return new Promise((resolve: any, reject: any): void => {
+
+      const isValidFunction: boolean = functionToInvoke !== undefined &&
+                                        functionToInvoke !== null &&
+                                        typeof functionToInvoke === 'function';
+
+      if (!isValidFunction) {
+        return resolve();
+      }
+
+      let result: any;
+      try {
+        result = functionToInvoke.call(invocationContext, invocationParameter);
+      } catch (error) {
+        return reject(error);
+      }
+
+      resolve(result);
+    });
+  }
 }

--- a/src/base_router.ts
+++ b/src/base_router.ts
@@ -36,26 +36,14 @@ export class BaseRouter implements IHttpRouter {
   public dispose(): Promise<void> | void { return; }
 
   // Taken from the foundation, to remove the need for that package.
-  private invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
+  private async invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
 
-    return new Promise((resolve: any, reject: any): void => {
+    const isValidFunction: boolean = typeof functionToInvoke === 'function';
 
-      const isValidFunction: boolean = functionToInvoke !== undefined &&
-                                        functionToInvoke !== null &&
-                                        typeof functionToInvoke === 'function';
+    if (!isValidFunction) {
+      return;
+    }
 
-      if (!isValidFunction) {
-        return resolve();
-      }
-
-      let result: any;
-      try {
-        result = functionToInvoke.call(invocationContext, invocationParameter);
-      } catch (error) {
-        return reject(error);
-      }
-
-      resolve(result);
-    });
+    return await functionToInvoke.call(invocationContext, invocationParameter);
   }
 }

--- a/src/http_extension.ts
+++ b/src/http_extension.ts
@@ -167,7 +167,7 @@ export class HttpExtension implements IHttpExtension {
   }
 
   // Taken from the foundation, to remove the need for that package.
-  private invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
+  protected invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
 
     return new Promise((resolve: any, reject: any): void => {
 

--- a/src/http_extension.ts
+++ b/src/http_extension.ts
@@ -1,4 +1,4 @@
-import {RouterDiscoveryTag} from '@essential-projects/bootstrapper_contracts';
+import {routerDiscoveryTag} from '@essential-projects/bootstrapper_contracts';
 import {IHttpExtension, IHttpRouter} from '@essential-projects/http_contracts';
 import {Container, IInstanceWrapper} from 'addict-ioc';
 import * as bodyParser from 'body-parser';
@@ -51,7 +51,7 @@ export class HttpExtension implements IHttpExtension {
 
     let routerNames: Array<string>;
 
-    const allRouterNames: Array<string> = this.container.getKeysByTags(RouterDiscoveryTag);
+    const allRouterNames: Array<string> = this.container.getKeysByTags(routerDiscoveryTag);
 
     this.container.validateDependencies();
 

--- a/src/http_extension.ts
+++ b/src/http_extension.ts
@@ -167,26 +167,14 @@ export class HttpExtension implements IHttpExtension {
   }
 
   // Taken from the foundation, to remove the need for that package.
-  protected invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
+  private async invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
 
-    return new Promise((resolve: any, reject: any): void => {
+    const isValidFunction: boolean = typeof functionToInvoke === 'function';
 
-      const isValidFunction: boolean = functionToInvoke !== undefined &&
-                                       functionToInvoke !== null &&
-                                       typeof functionToInvoke === 'function';
+    if (!isValidFunction) {
+      return;
+    }
 
-      if (!isValidFunction) {
-        return resolve();
-      }
-
-      let result: any;
-      try {
-        result = functionToInvoke.call(invocationContext, invocationParameter);
-      } catch (error) {
-        return reject(error);
-      }
-
-      resolve(result);
-    });
+    return await functionToInvoke.call(invocationContext, invocationParameter);
   }
 }

--- a/src/http_extension.ts
+++ b/src/http_extension.ts
@@ -1,7 +1,4 @@
-/* tslint:disable:no-empty */
-
-import {RouterDiscoveryTag} from '@essential-projects/core_contracts';
-import {runtime} from '@essential-projects/foundation';
+import {RouterDiscoveryTag} from '@essential-projects/bootstrapper_contracts';
 import {IHttpExtension, IHttpRouter} from '@essential-projects/http_contracts';
 import {Container, IInstanceWrapper} from 'addict-ioc';
 import * as bodyParser from 'body-parser';
@@ -43,11 +40,11 @@ export class HttpExtension implements IHttpExtension {
   }
 
   public async initialize(): Promise<void> {
-    await runtime.invokeAsPromiseIfPossible(this.initializeAppExtensions, this, this.app);
+    await this.invokeAsPromiseIfPossible(this.initializeAppExtensions, this, this.app as any);
     this.initializeBaseMiddleware(this.app);
-    await runtime.invokeAsPromiseIfPossible(this.initializeMiddlewareBeforeRouters, this, this.app);
+    await this.invokeAsPromiseIfPossible(this.initializeMiddlewareBeforeRouters, this, this.app as any);
     await this.initializeRouters();
-    await runtime.invokeAsPromiseIfPossible(this.initializeMiddlewareAfterRouters, this, this.app);
+    await this.invokeAsPromiseIfPossible(this.initializeMiddlewareAfterRouters, this, this.app as any);
   }
 
   protected initializeRouters(): Promise<void> {
@@ -58,23 +55,15 @@ export class HttpExtension implements IHttpExtension {
 
     this.container.validateDependencies();
 
-    return runtime.invokeAsPromiseIfPossible(this.filterRouters, this, allRouterNames)
-      .then((filteredRouterNames) => {
+    return this.invokeAsPromiseIfPossible(this.filterRouters, this, allRouterNames)
+      .then((filteredRouterNames: Array<string>) => {
 
         if (typeof filteredRouterNames === 'undefined' || filteredRouterNames === null) {
-
           routerNames = allRouterNames;
-
         } else {
 
           if (!Array.isArray(filteredRouterNames)) {
-
             throw new Error('Filtered router names must be of type Array.');
-
-          } else if (filteredRouterNames.length === 0) {
-
-            // logger.warn(`Array of filtered router names is empty. Check the filterRouters()
-            //   extension hook in your http extension.`);
           }
 
           routerNames = filteredRouterNames;
@@ -99,8 +88,6 @@ export class HttpExtension implements IHttpExtension {
   }
 
   protected async initializeRouter(routerName: string): Promise<void> {
-
-    // logger.debug(`initialize ${routerName}`);
 
     if (!this.container.isRegistered(routerName)) {
 
@@ -127,7 +114,7 @@ export class HttpExtension implements IHttpExtension {
 
       this._server = this.app.listen(this.config.server.port, this.config.server.host, () => {
 
-        runtime.invokeAsPromiseIfPossible(this.onStarted, this)
+        this.invokeAsPromiseIfPossible(this.onStarted, this)
           .then((result: any) => {
             resolve(result);
           })
@@ -143,7 +130,7 @@ export class HttpExtension implements IHttpExtension {
 
     for (const routerName in this.routers) {
       const router: IHttpRouter = this.routers[routerName];
-      await runtime.invokeAsPromiseIfPossible(router.dispose, router);
+      await this.invokeAsPromiseIfPossible(router.dispose, router);
     }
 
     await new Promise(async(resolve: Function, reject: Function): Promise<void> => {
@@ -172,18 +159,34 @@ export class HttpExtension implements IHttpExtension {
 
   protected initializeBaseMiddleware(app): void {
 
-    // app.use(ExpressLogger('combined', {
-    //   stream: {
-    //     write: function(message: string) {
-    //       logger.info(message);
-    //     }
-    //   }
-    // }));
-
     const opts: any = {};
     if (this.config && this.config.parseLimit) {
       opts.limit = this.config.parseLimit;
     }
     app.use(bodyParser.json(opts));
+  }
+
+  // Taken from the foundation, to remove the need for that package.
+  private invokeAsPromiseIfPossible(functionToInvoke: any, invocationContext: any, invocationParameter?: Array<any>): Promise<any> {
+
+    return new Promise((resolve: any, reject: any): void => {
+
+      const isValidFunction: boolean = functionToInvoke !== undefined &&
+                                       functionToInvoke !== null &&
+                                       typeof functionToInvoke === 'function';
+
+      if (!isValidFunction) {
+        return resolve();
+      }
+
+      let result: any;
+      try {
+        result = functionToInvoke.call(invocationContext, invocationParameter);
+      } catch (error) {
+        return reject(error);
+      }
+
+      resolve(result);
+    });
   }
 }


### PR DESCRIPTION
## What did you change?

- Removes all dependencies to the `core_contracts` and `foundation` packages
  - The `invokeAsPromiseIfPossible` function was imported, to guarantee that no functionality will be affected
- Use `bootstrapper_contracts` package to get the discovery tags

## How can others test the changes?

The extension should run as it did before.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
